### PR TITLE
Add a ability to specify group. Fix required

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Generates and inject [apidoc](http://apidoc.com) elements from api schemas.
 
-`@apiSchema {SCHEMA_TYPE=PATH_TO_SCHEMA} ELEMENT_TYPE`
+`@apiSchema [(group)] {SCHEMA_TYPE=PATH_TO_SCHEMA} ELEMENT_TYPE`
 
 ## Install
 `npm install apidoc-plugin-schema --save-dev`
@@ -23,7 +23,7 @@ Generates and inject [apidoc](http://apidoc.com) elements from api schemas.
 ```javascript
 /**
  * @api {get} /api GetAPI
- * @apiSchema {jsonschema=./schema/api.req.json} apiParam
+ * @apiSchema (Body) {jsonschema=./schema/api.req.json} apiParam
  * @apiSchema {jsonschema=./schema/api.res.json} apiSuccess
  */
 ```

--- a/index.js
+++ b/index.js
@@ -9,30 +9,27 @@ var schemas = {
 var app = {};
 
 module.exports = {
-
-    init: function(_app) {
-        app = _app;
-        app.addHook('parser-find-elements', parserSchemaElements);
-    }
-
+  init: function(_app) {
+    app = _app;
+    app.addHook('parser-find-elements', parserSchemaElements);
+  }
 };
 
 function parserSchemaElements(elements, element, block, filename) {
-    if ( element.name === 'apischema' ) {
-		//app.log.verbose('element',element);
-        elements.pop();
+  if ( element.name === 'apischema' ) {
+    elements.pop();
 
-        var values = elementParser.parse(element.content, element.source);
-        app.log.debug('apischema.path',values.path);
+    var values = elementParser.parse(element.content, element.source);
+    app.log.debug('apischema.path',values.path);
 		if (schemas[values.schema]) {
 			var data = fs.readFileSync( path.join(path.dirname(filename), values.path), 'utf8').toString();
-			var new_elements = schemas[values.schema](data, values.element, app.parser.parsers[values.element.toLowerCase()]);
+			var new_elements = schemas[values.schema](data, values.element, values.group);
 
 			// do not use concat
 			for(var i = 0,l=new_elements.length; i<l;i++) {
 				elements.push(new_elements[i]);
 			}
 		}
-    }
-    return elements;
+  }
+  return elements;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name":"apidoc-plugin-schema",
-  "version":"0.0.9",
+  "version":"0.1.0",
   "description": "Schema Plugin for apidoc.",
 	"copyright": "Copyright (c) 2016 will Farrell. All rights reserved.",
 	"license": "MIT",

--- a/parser/api_schema.js
+++ b/parser/api_schema.js
@@ -6,17 +6,18 @@ function parse(content) {
 	if (content.length === 0)
 		return null;
 	
-	// @apiSchema {jsonschema=relative_path} additional_argument
-	var parseRegExp = /^\{(.+?)=(.+?)\}\s*(?:\s+(.+?))?$/g;
+	// @apiSchema (optional group) {jsonschema=relative_path} additional_argument
+	var parseRegExp = /^(?:\((.+?)\)){0,1}\s*\{(.+?)=(.+?)\}\s*(?:(.+))?/g;
 	var matches = parseRegExp.exec(content);
 
 	if ( ! matches)
 		return null;
 
 	return {
-		schema : matches[1],
-		path : matches[2],
-		element : matches[3] || 'apiParam'
+		group: matches[1],
+		schema : matches[2],
+		path : matches[3],
+		element : matches[4] || 'apiParam',
 	};
 }
 


### PR DESCRIPTION
Add ability to specify the group name to the @apiSchema tag
Nest attributes instead of creating new group for child objects
Have `isRequired` to also check for `property[key].required = true`
Use first object in array type for documentation type
