### PR TITLE
Making $ref relative to schema file

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var schemas = {
 };
 
 var app = {};
-
+                    
 module.exports = {
   init: function(_app) {
     app = _app;
@@ -22,8 +22,9 @@ function parserSchemaElements(elements, element, block, filename) {
     var values = elementParser.parse(element.content, element.source);
     app.log.debug('apischema.path',values.path);
 		if (schemas[values.schema]) {
-			var data = fs.readFileSync( path.join(path.dirname(filename), values.path), 'utf8').toString();
-			var new_elements = schemas[values.schema](data, values.element, values.group);
+      var relativePath=path.join(path.dirname(filename), values.path);
+			var data = fs.readFileSync(relativePath, 'utf8').toString();
+			var new_elements = schemas[values.schema](relativePath, data, values.element, values.group);
 
 			// do not use concat
 			for(var i = 0,l=new_elements.length; i<l;i++) {

--- a/schema/jsonschema.js
+++ b/schema/jsonschema.js
@@ -211,12 +211,12 @@ function traverse(schema, p, group) {
 }
 
 var $RefParser = require('json-schema-ref-parser');
-function build (data, element, group) {
+function build (relativePath, data, element, group) {
 	data = JSON.parse(data);
 
 	// run sync - https://github.com/BigstickCarpet/json-schema-ref-parser/issues/14
 	var elements = [], done = false;
-	$RefParser.dereference(data, function(err, schema) {
+	$RefParser.dereference(relativePath, data, {}, function(err, schema) {
 		if (err) {
 			console.error(err);
 			done = true;


### PR DESCRIPTION
Hi,
i make small change in handling $ref inside schema files.
**Example:**
File structure:
/folderA/example.js (with @apiSchema...)
/folderB/schemaA.json
/folderB/schemaB.json

**Prior to this change:**
If you wanted to make relative $ref from schemaA to schemaB you needed to make something like this:
"$ref": "../folderB/schemaB.json" (because relative path was based on location where apidoc command was executed)

**My version:**
$ref is relative to file that containst it.
"$ref": "schemaB.json"

I think that this is also only way how $ref should be handled inside json schema, but i could be mistaken.
