### PR TITLE
Support for generating examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
 	],
   "dependencies": {
     "trim": "0.0.1",
-    "json-schema-ref-parser":"*",
+    "json-schema-ref-parser":"*",    
+    "json-schema-faker": "*",
     "deasync":"*"
   }
 }

--- a/schema/jsonschema.js
+++ b/schema/jsonschema.js
@@ -211,6 +211,7 @@ function traverse(schema, p, group) {
 }
 
 var $RefParser = require('json-schema-ref-parser');
+var jsf = require('json-schema-faker');
 function build (relativePath, data, element, group) {
 	data = JSON.parse(data);
 
@@ -219,21 +220,35 @@ function build (relativePath, data, element, group) {
 	$RefParser.dereference(relativePath, data, {}, function(err, schema) {
 		if (err) {
 			console.error(err);
-			done = true;
-			return;
 		}
-		var lines = traverse(schema, null, group);
-		for(var l in lines) {
-			if (!lines.hasOwnProperty(l)) { continue; }
+    else if(element.endsWith('Example'))
+    {
+        var faker=jsf(schema); 
+		    var g = group ? ''+group+' ' : ' Example: ';
+        var con = ' {json} '+g+'\n'+JSON.stringify(faker,null,4);
+        var res = {
+          source: '@'+element+con,   
+				  name: element.toLowerCase(),
+				  sourceName: element,
+          content: con+'\n'
+        };
+        elements.push(res);
+    }
+    else
+    {
+		  var lines = traverse(schema, null, group);   
+		  for(var l in lines) {
+			   if (!lines.hasOwnProperty(l)) { continue; }
 			
-			var res = { 
-				source: '@'+element+' '+lines[l]+'\n',
-				name: element.toLowerCase(),
-				sourceName: element,
-				content: lines[l]+'\n'
-			};
-			elements.push(res);
-		}
+			   var res = { 
+				  source: '@'+element+' '+lines[l]+'\n',
+				  name: element.toLowerCase(),
+				  sourceName: element,
+				  content: lines[l]+'\n'
+			   }; 
+			   elements.push(res);
+		  }
+    }
 		done = true;
 	});
 	require('deasync').loopWhile(function(){return !done;});


### PR DESCRIPTION
Hi,
this allow user to use json schema for generating examples. (@apiErrorExample, @apiHeaderExample, @apiParamExample and @apiSuccessExample) via: 
`@apiSchema (Title) {jsonschema=schema.json} apiSuccessExample`

Generation of example is done via json-schema-faker, so it can benefit from all its functions.
For instance json schema:
{
  "type": "string",
  "faker": "internet.email"
}
Will generate random email address. 
For more information look [here](http://json-schema-faker.js.org) or [here](https://www.npmjs.com/package/json-schema-faker#faking-values)

Possible problems with this:
1) Generated examples changes each generation. (But this can be prevented by specifying value for faker)
2) This code for [Title] in @apiHeaderExample,... uses {Group} from @apiSchema (or 'Example:' if group wasn´t specified). This could be somewhat misleading for user.