### PR TITLE
Show description as empty instead of "undefined"

### DIFF
--- a/schema/jsonschema.js
+++ b/schema/jsonschema.js
@@ -177,9 +177,9 @@ function traverse(schema, p, group) {
 		var size = makeSize(param);
 		var allowedValues = makeAllowedValues(param);
 
-		var description = param.description;
+		var description = param.description || '';
 		if (param.type === 'array') {
-			description += ' '+param.items.description;
+			description += ' '+ (param.items.description || '');
 		}
 
 		// make field


### PR DESCRIPTION
When the description value isn't specified, the docs generated currently show "undefined" in the description field. This change is so nothing is shown if `description` isn't populated in the schema.