### PR TITLE
isRequired type-safety

### DIFF
--- a/schema/jsonschema.js
+++ b/schema/jsonschema.js
@@ -119,8 +119,8 @@ function isRequired(schema, key) {
 	if (schema.type === 'array') { schema = schema.items; }
 
 	// TODO figure out way to display when anyOf, oneOf
-	return (exists(Object.keys(schema),'required') && (schema.required.indexOf(key) !== -1)) ||
-					(exists(Object.keys(schema.properties), key) && schema.properties[key].required);
+	return (exists(Object.keys(schema),'required') && Array.isArray(schema.required) && (schema.required.indexOf(key) !== -1)) ||
+					(exists(Object.keys(schema.properties), key) && (typeof schema.properties[key].required === 'boolean') && schema.properties[key].required);
 }
 
 // NOTE this is not proper jsonschema, likely in v5 w/ merge


### PR DESCRIPTION
With nested objects in schema, "required" key can have either array or boolean value. It causes bugs (e.g. it may call indexOf on boolean or consider array to be truthy value).
This PR adds an additional verification if type of "required" attribute is correct one.